### PR TITLE
Remove CRON job from CI to prevent multiple CD deployments 

### DIFF
--- a/.github/workflows/leaders-ci.yml
+++ b/.github/workflows/leaders-ci.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -27,4 +25,3 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cd leaders && docker build -t ghcr.io/jakejack13/speed-leaders:latest .
-

--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -27,4 +25,3 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cd workers && docker build -t ghcr.io/jakejack13/speed-workers:latest .
-


### PR DESCRIPTION
### Description

The CI job is currently configured to run every midnight. The CD pipeline triggers on a successful CI run, which will cause deployments every midnight. This PR removes that CRON job