### PR TITLE
#20: Fix Docker build caching

### DIFF
--- a/leaders/Dockerfile
+++ b/leaders/Dockerfile
@@ -5,12 +5,9 @@
 FROM gradle:8.4.0-jdk AS build
 ENV APP_HOME=/app/
 WORKDIR $APP_HOME
-COPY build.gradle settings.gradle $APP_HOME
 
+COPY build.gradle settings.gradle $APP_HOME
 COPY gradle $APP_HOME/gradle
-COPY --chown=gradle:gradle . /home/gradle/src
-USER root
-RUN chown -R gradle /home/gradle/src
 
 RUN gradle build || return 0
 COPY . .

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -5,12 +5,9 @@
 FROM gradle:8.4.0-jdk AS build
 ENV APP_HOME=/app/
 WORKDIR $APP_HOME
-COPY build.gradle settings.gradle $APP_HOME
 
+COPY build.gradle settings.gradle $APP_HOME
 COPY gradle $APP_HOME/gradle
-COPY --chown=gradle:gradle . /home/gradle/src
-USER root
-RUN chown -R gradle /home/gradle/src
 
 RUN gradle build || return 0
 COPY . .


### PR DESCRIPTION
### Summary

Previously, the Docker images for both workers and leaders would copy all project files, build to cache dependencies, and then build again. However, we should only be copying the grade files to cache dependencies, then copy the rest of the project and build. This fix should speed up build times and cache Docker layers correctly.

Issue: #20 