### PR TITLE
#14: Create test partitioner for JUnit5 Repositories on leader

### DIFF
--- a/.run/leaders Main.run.xml
+++ b/.run/leaders Main.run.xml
@@ -4,6 +4,7 @@
       <env name="SPEED_REPO_URL" value="https://github.com/owenxr/SPEED-TESTER" />
       <env name="SPEED_REPO_BRANCH" value="main" />
       <env name="SPEED_KAFKA_ADDRESS" value="localhost:9092" />
+      <env name="SPEED_NUM_WORKERS" value="2" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="edu.cornell.Main" />
     <module name="leaders.main" />

--- a/leaders/build.gradle
+++ b/leaders/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r'
     implementation 'com.github.docker-java:docker-java-core:3.3.4'
     implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.3.4'
+    implementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    implementation 'org.junit.jupiter:junit-jupiter:5.9.1'
 
     implementation 'org.slf4j:slf4j-api:2.0.7'
     implementation 'org.slf4j:slf4j-simple:2.0.7'

--- a/leaders/src/main/java/edu/cornell/Main.java
+++ b/leaders/src/main/java/edu/cornell/Main.java
@@ -2,12 +2,11 @@ package edu.cornell;
 
 import edu.cornell.partitioner.ClassPartitioner;
 import edu.cornell.partitioner.methods.NumSplitPartitionMethod;
-import edu.cornell.repository.Config;
-import edu.cornell.repository.Repository;
-import edu.cornell.repository.RepositoryCloneException;
-import edu.cornell.repository.RepositoryFactory;
+import edu.cornell.repository.*;
 import edu.cornell.testconsumer.TestConsumer;
 import edu.cornell.worker.Worker;
+
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -71,9 +70,14 @@ public class Main {
         Set<String> tests = Set.of();
         try {
             Repository repository = RepositoryFactory.fromGitRepo(url, branch);
+            LOGGER.info("Building");
+            repository.build(repository.getConfig().getBuildCommands());
             tests = repository.getTests();
         } catch (RepositoryCloneException e) {
             LOGGER.error("Unable to clone the repository", e);
+            System.exit(1);
+        } catch (RepositoryBuildException e) {
+            LOGGER.error("Unable to build the repository", e);
             System.exit(1);
         }
 

--- a/leaders/src/main/java/edu/cornell/Main.java
+++ b/leaders/src/main/java/edu/cornell/Main.java
@@ -1,7 +1,13 @@
 package edu.cornell;
 
+import edu.cornell.repository.Repository;
+import edu.cornell.repository.RepositoryCloneException;
+import edu.cornell.repository.RepositoryFactory;
 import edu.cornell.testconsumer.TestConsumer;
 import edu.cornell.worker.Worker;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,18 +44,38 @@ public class Main {
      */
     public static final @NonNull String ENV_KAFKA_ADDRESS = "SPEED_KAFKA_ADDRESS";
 
+    /**
+     * The name of the NUM_WORKERS environment variable
+     */
+    public static final @NonNull String ENV_NUM_WORKERS = "SPEED_NUM_WORKERS";
+
     public static void main(String[] args) {
         String kafkaAddress = System.getenv(ENV_KAFKA_ADDRESS);
         String url = System.getenv(ENV_REPO_URL);
         String branch = System.getenv(ENV_REPO_BRANCH);
+        int numWorkers = 0;
+        try {
+            numWorkers = Integer.parseInt(System.getenv(ENV_NUM_WORKERS));
+        } catch (NumberFormatException e) {
+            LOGGER.info("Incorrect integer format", e);
+            System.exit(1);
+        }
         if (url == null || branch == null || kafkaAddress == null) {
             LOGGER.error("Environment variables missing");
             System.exit(1);
         }
-        // TODO: Find tests, assign tests to workers
 
-        Set<String> tests = Set.of("org.example.CalcTest"); // FIXME: Replace
-        try (CloseableSet<Worker> workers = createWorkerSet(url, branch, tests, kafkaAddress);
+        Set<String> tests = Set.of();
+        try {
+            Repository repository = RepositoryFactory.fromGitRepo(url, branch);
+            tests = repository.getTests();
+        } catch (RepositoryCloneException e) {
+            LOGGER.error("Unable to clone the repository", e);
+            System.exit(1);
+        }
+
+        try (CloseableSet<Worker> workers = createWorkerSet(url, branch, tests, numWorkers,
+                kafkaAddress);
                 WorkerRunner workerRunner = new WorkerRunner(workers);
                 KafkaConsumerRunner kafkaRunner =
                     new KafkaConsumerRunner(kafkaAddress, getWorkerIds(workers),
@@ -72,13 +98,20 @@ public class Main {
      * @param url the url of the repository to test
      * @param branch the branch of the repository to test
      * @param tests the set of tests to execute
+     * @param numWorkers the number of workers to create
      * @param kafkaAddress the Kafka message bus address
      * @return the set of workers
      */
     private static @NonNull CloseableSet<Worker> createWorkerSet(String url, String branch,
-            Set<String> tests, String kafkaAddress) {
+            Set<String> tests, int numWorkers, String kafkaAddress) {
+        List<String> testsList = new ArrayList<>(tests);
         CloseableSet<Worker> workers = new CloseableSet<>();
-        workers.add(Worker.createWorker(url, branch, tests, kafkaAddress));
+        for (int i = 0; i < testsList.size(); i += testsList.size()/numWorkers) {
+            workers.add(Worker.createWorker(url,
+                    branch,
+                    new HashSet<>(testsList.subList(i, Math.max(i+numWorkers, testsList.size()))),
+                    kafkaAddress));
+        }
         return workers;
     }
 

--- a/leaders/src/main/java/edu/cornell/Main.java
+++ b/leaders/src/main/java/edu/cornell/Main.java
@@ -2,17 +2,17 @@ package edu.cornell;
 
 import edu.cornell.partitioner.ClassPartitioner;
 import edu.cornell.partitioner.methods.NumSplitPartitionMethod;
-import edu.cornell.repository.*;
+import edu.cornell.repository.Repository;
+import edu.cornell.repository.RepositoryBuildException;
+import edu.cornell.repository.RepositoryCloneException;
+import edu.cornell.repository.RepositoryFactory;
 import edu.cornell.testconsumer.TestConsumer;
 import edu.cornell.worker.Worker;
-
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/leaders/src/main/java/edu/cornell/Main.java
+++ b/leaders/src/main/java/edu/cornell/Main.java
@@ -55,6 +55,7 @@ public class Main {
         String kafkaAddress = System.getenv(ENV_KAFKA_ADDRESS);
         String url = System.getenv(ENV_REPO_URL);
         String branch = System.getenv(ENV_REPO_BRANCH);
+
         int numWorkers = 0;
         try {
             numWorkers = Integer.parseInt(System.getenv(ENV_NUM_WORKERS));
@@ -62,6 +63,7 @@ public class Main {
             LOGGER.info("Incorrect integer format", e);
             System.exit(1);
         }
+
         if (url == null || branch == null || kafkaAddress == null) {
             LOGGER.error("Environment variables missing");
             System.exit(1);

--- a/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Class that handles and stores the partitioned classes based on desired method.
+ */
 @Slf4j
 public class ClassPartitioner {
 

--- a/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
@@ -1,0 +1,66 @@
+package edu.cornell.partitioner;
+
+import edu.cornell.partitioner.methods.PartitionMethod;
+import edu.cornell.repository.Config;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ClassPartitioner {
+
+    private List<Set<String>> classes;
+    private PartitionMethod partitionMethod;
+
+    //TODO: Change when config is reconfigured
+    public ClassPartitioner(PartitionMethod partitionClass, List<String> tests, int partitions) {
+        this.partitionMethod = partitionClass;
+        classes = partitionClasses(tests, partitions);
+    }
+
+    public @NonNull List<Set<String>> getClasses() {
+        return classes;
+    }
+
+    private List<Set<String>> partitionClasses(List<String> tests, int partitions) {
+        List<Set<String>> classes = partitionMethod.partition(tests, partitions);
+        return classes;
+    }
+
+//    private List<String> loadClassesFromDirectory(String directoryPath) throws PathIsNotValidException {
+//        File directory = new File(directoryPath);
+//
+//        // Check if the directory is valid
+//        if (!directory.exists() || !directory.isDirectory()) {
+//            throw new PathIsNotValidException("The given path " + directory.toPath() + " is invalid (missing or not a directory).", null);
+//        }
+//
+//        List<String> classes = new ArrayList<>();
+//
+//        // Add all .class or .jar files within subdirectories
+//        addFilesRecursively(directory, classes);
+//
+//        return classes;
+//    }
+//
+//    //Add all the .class or .jar files from the given directory
+//    private void addFilesRecursively(File directory, List<String> classes) {
+//        File[] files = directory.listFiles();
+//
+//        if (files != null) {
+//            for (File file : files) {
+//                if (file.isDirectory()) {
+//                    addFilesRecursively(file, classes);
+//                } else if (file.isFile() && (file.getName().endsWith(".class") || file.getName().endsWith(".jar"))) {
+//                    classes.add(file.getName());
+//                }
+//            }
+//        }
+//    }
+
+}

--- a/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
@@ -35,35 +35,4 @@ public class ClassPartitioner {
         return classes;
     }
 
-//    private List<String> loadClassesFromDirectory(String directoryPath) throws PathIsNotValidException {
-//        File directory = new File(directoryPath);
-//
-//        // Check if the directory is valid
-//        if (!directory.exists() || !directory.isDirectory()) {
-//            throw new PathIsNotValidException("The given path " + directory.toPath() + " is invalid (missing or not a directory).", null);
-//        }
-//
-//        List<String> classes = new ArrayList<>();
-//
-//        // Add all .class or .jar files within subdirectories
-//        addFilesRecursively(directory, classes);
-//
-//        return classes;
-//    }
-//
-//    //Add all the .class or .jar files from the given directory
-//    private void addFilesRecursively(File directory, List<String> classes) {
-//        File[] files = directory.listFiles();
-//
-//        if (files != null) {
-//            for (File file : files) {
-//                if (file.isDirectory()) {
-//                    addFilesRecursively(file, classes);
-//                } else if (file.isFile() && (file.getName().endsWith(".class") || file.getName().endsWith(".jar"))) {
-//                    classes.add(file.getName());
-//                }
-//            }
-//        }
-//    }
-
 }

--- a/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
@@ -16,7 +16,6 @@ public class ClassPartitioner {
     private List<Set<String>> classes;
     private PartitionMethod partitionMethod;
 
-    //TODO: Change when config is reconfigured
     public ClassPartitioner(PartitionMethod partitionClass, List<String> tests, int partitions) {
         this.partitionMethod = partitionClass;
         classes = partitionClasses(tests, partitions);

--- a/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/ClassPartitioner.java
@@ -1,15 +1,11 @@
 package edu.cornell.partitioner;
 
 import edu.cornell.partitioner.methods.PartitionMethod;
-import edu.cornell.repository.Config;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Class that handles and stores the partitioned classes based on desired method.

--- a/leaders/src/main/java/edu/cornell/partitioner/PathIsNotValidException.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/PathIsNotValidException.java
@@ -1,0 +1,21 @@
+package edu.cornell.partitioner;
+
+import java.io.Serial;
+
+/**
+ * Exception is thrown when the given path is not a directory or does not exist
+ */
+public class PathIsNotValidException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1234L;
+
+    /**
+     * Creates a new PathIsNotValidException with the given message and backtrace
+     * @param message the message of the exception
+     * @param backtrace the backtrace of the exception
+     */
+    public PathIsNotValidException(String message, Throwable backtrace) {
+        super(message, backtrace);
+    }
+}

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
@@ -6,8 +6,18 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Provides method that divides classes equally among a set number of partitions
+ */
 public class NumSplitPartitionMethod extends PartitionMethod {
 
+    /**
+     * Split the list of classes into equal number of input partitions. <br></br> If lists cannot be divided evenly among
+     * partitions, include one extra test in each test set up until the modulus of className size and partitions.
+     * @param classNames - List of the classes by package+name
+     * @param partitions - Number of partitions to create
+     * @return
+     */
     @Override
     public List<Set<String>> partition(List<String> classNames, int partitions) {
         List<Set<String>> classes = new ArrayList<>();

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
@@ -24,11 +24,12 @@ public class NumSplitPartitionMethod extends PartitionMethod {
         int listSize = classNames.size();
 
         int startIndex = 0;
+        int partitionSize;
         int overflow = listSize % partitions;
         int endIndex;
 
         for (int i = 0; i < partitions; i++) {
-            int partitionSize = (listSize / partitions) + (overflow > 0 ? 1 : 0);
+            partitionSize = (listSize / partitions) + (overflow > 0 ? 1 : 0);
             endIndex = startIndex + partitionSize;
 
             if(endIndex > listSize) {

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
@@ -15,7 +15,7 @@ public class NumSplitPartitionMethod extends PartitionMethod {
      * partitions, include one extra test in each test set up until the modulus of className size and partitions.
      * @param classNames - List of the classes by package+name
      * @param partitions - Number of partitions to create
-     * @return
+     * @return A list of approximately evenly split test class name partitions stored as sets
      */
     @Override
     public List<Set<String>> partition(List<String> classNames, int partitions) {

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Provides method that divides classes equally among a set number of partitions

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/NumSplitPartitionMethod.java
@@ -1,0 +1,39 @@
+package edu.cornell.partitioner.methods;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class NumSplitPartitionMethod extends PartitionMethod {
+
+    @Override
+    public List<Set<String>> partition(List<String> classNames, int partitions) {
+        List<Set<String>> classes = new ArrayList<>();
+
+        int listSize = classNames.size();
+
+        int startIndex = 0;
+        int overflow = listSize % partitions;
+        int endIndex;
+
+        for (int i = 0; i < partitions; i++) {
+            int partitionSize = (listSize / partitions) + (overflow > 0 ? 1 : 0);
+            endIndex = startIndex + partitionSize;
+
+            if(endIndex > listSize) {
+                endIndex = listSize;
+            }
+
+            classes.add(new HashSet<>(classNames.subList(startIndex, endIndex)));
+
+            startIndex = endIndex;
+            if(overflow > 0) { overflow--; }
+
+        }
+
+        return classes;
+    }
+
+}

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/PartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/PartitionMethod.java
@@ -1,0 +1,10 @@
+package edu.cornell.partitioner.methods;
+
+import java.util.List;
+import java.util.Set;
+
+public abstract class PartitionMethod {
+
+    abstract public List<Set<String>> partition(List<String> classNames, int partitions);
+
+}

--- a/leaders/src/main/java/edu/cornell/partitioner/methods/PartitionMethod.java
+++ b/leaders/src/main/java/edu/cornell/partitioner/methods/PartitionMethod.java
@@ -3,8 +3,17 @@ package edu.cornell.partitioner.methods;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Class that provides the partitioning method to be used to split classes among workers
+ */
 public abstract class PartitionMethod {
 
+    /**
+     * Partitioning method to split the classes based on the number of partitions
+     * @param classNames - List of the classes by package+name
+     * @param partitions - Number of partitions to create
+     * @return A list of test class name partitions stored as sets
+     */
     abstract public List<Set<String>> partition(List<String> classNames, int partitions);
 
 }

--- a/leaders/src/main/java/edu/cornell/repository/Config.java
+++ b/leaders/src/main/java/edu/cornell/repository/Config.java
@@ -1,10 +1,11 @@
 package edu.cornell.repository;
 
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * An object representing the SPEED config file in the repository

--- a/leaders/src/main/java/edu/cornell/repository/Config.java
+++ b/leaders/src/main/java/edu/cornell/repository/Config.java
@@ -1,0 +1,38 @@
+package edu.cornell.repository;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An object representing the SPEED config file in the repository
+ */
+@Slf4j
+public class Config {
+
+    /**
+     * Parser for parsing config file.
+     */
+    private ConfigParser parser;
+
+    /**
+     * Creates config file.
+     */
+    public Config(String configFilePath) throws ConfigSyntaxException {
+        try {
+            parser = new ConfigParser(Path.of(configFilePath));
+        } catch (IOException e) {
+            LOGGER.error("Error reading config file from disk", e);
+            System.exit(1);
+        }
+    }
+    /**
+     * Returns the list of commands to build the repository
+     * @return the list of commands to build the repository
+     */
+    public @NonNull List<String> getBuildCommands() {
+        return parser.getConfigMapCategory(ConfigParser.Category.BUILD_COMMANDS);
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/Config.java
+++ b/leaders/src/main/java/edu/cornell/repository/Config.java
@@ -35,4 +35,8 @@ public class Config {
     public @NonNull List<String> getBuildCommands() {
         return parser.getConfigMapCategory(ConfigParser.Category.BUILD_COMMANDS);
     }
+
+    public @NonNull List<String> getTestPaths() {
+        return parser.getConfigMapCategory(ConfigParser.Category.TEST_PATHS);
+    }
 }

--- a/leaders/src/main/java/edu/cornell/repository/Config.java
+++ b/leaders/src/main/java/edu/cornell/repository/Config.java
@@ -36,6 +36,10 @@ public class Config {
         return parser.getConfigMapCategory(ConfigParser.Category.BUILD_COMMANDS);
     }
 
+    /**
+     * Return list of strings representing TEST_PATHS specified in the config
+     * @return list of strings of path to project files
+     */
     public @NonNull List<String> getTestPaths() {
         return parser.getConfigMapCategory(ConfigParser.Category.TEST_PATHS);
     }

--- a/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
+++ b/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
@@ -71,7 +71,7 @@ public class ConfigParser {
             } else if (line.startsWith("-")) {
                 if (!categoryOpen)
                     throw new ConfigSyntaxException("Item outside of a category: " + line);
-                currentItems.add(line.substring(1));
+                currentItems.add(line.substring(1).trim());
             } else if (!line.trim().isEmpty()) {
                 if (!categoryOpen || currentItems.isEmpty())
                     throw new ConfigSyntaxException("Continuation line outside of an item: " + line);

--- a/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
+++ b/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
@@ -1,0 +1,107 @@
+package edu.cornell.repository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import lombok.NonNull;
+
+/**
+ * Parses the config file of the repository.
+ * Expected format of config file is as follows:
+ * CATEGORY::
+ * - inputOne of the category
+ * - inputTwo of the category
+ * this is still inputTwo because there was no dash
+ * ::
+ *
+ * CATEGORY::
+ * - inputOne of the category
+ * this is still inputOne because there was no dash
+ * ::
+ */
+public class ConfigParser {
+    /**
+     * Maps the category to the category's respective information from the config file.
+     */
+    private EnumMap<Category, List<String>> configMap = new EnumMap<>(Category.class);
+
+    /**
+     * Path of the config file
+     */
+    private final @NonNull Path configFilePath;
+
+    /**
+     * Parses config files
+     * @param configFilePath Path of the config file.
+     */
+    public ConfigParser(Path configFilePath) throws IOException, ConfigSyntaxException {
+        this.configFilePath = configFilePath;
+        parseConfig();
+    }
+
+    /**
+     * Parses config file and puts all categories in map.
+     * @throws IOException if can't read config file.
+     * @throws ConfigSyntaxException if config file syntax is incorrect.
+     */
+    private void parseConfig() throws IOException, ConfigSyntaxException {
+        List<String> lines = Files.readAllLines(this.configFilePath);
+        Category currentCategory = null;
+        ArrayList<String> currentItems = new ArrayList<>();
+        boolean categoryOpen = false;
+
+        for (String line : lines) {
+            if (line.endsWith("::") && !line.startsWith("::")) {
+                String categoryName = line.substring(0, line.length() - 2);
+                try {
+                    currentCategory = Category.valueOf(categoryName.trim().toUpperCase().replace(" ", "_"));
+                    currentItems = new ArrayList<>();
+                    categoryOpen = true;
+                } catch (IllegalArgumentException e) {
+                    throw new ConfigSyntaxException("Invalid category name: " + categoryName.trim());
+                }
+            } else if (line.trim().equals("::")) {
+                if (!categoryOpen)
+                    throw new ConfigSyntaxException("Category end marker :: found without a matching start marker.");
+                configMap.put(currentCategory, currentItems);
+                categoryOpen = false;
+            } else if (line.startsWith("-")) {
+                if (!categoryOpen)
+                    throw new ConfigSyntaxException("Item outside of a category: " + line);
+                currentItems.add(line.substring(1));
+            } else if (!line.trim().isEmpty()) {
+                if (!categoryOpen || currentItems.isEmpty())
+                    throw new ConfigSyntaxException("Continuation line outside of an item: " + line);
+                int lastIndex = currentItems.size() - 1;
+                String lastItem = currentItems.get(lastIndex);
+                currentItems.set(lastIndex, lastItem + line);
+            }
+        }
+
+        if (categoryOpen)
+            throw new ConfigSyntaxException("File ended without closing category with ::");
+    }
+
+
+    /**
+     * Gets the values associated with the config category.
+     * @param categoryType The type of category to get the information of.
+     * @return A List of the category values as strings or null if category doesn't exist.
+     */
+    public List<String> getConfigMapCategory(Category categoryType) {
+        return configMap.get(categoryType);
+    }
+
+    /**
+     * The currently supported categories of information in the config file.
+     * Needs updated for each new category supported.
+     */
+    public enum Category {
+        BUILD_COMMANDS,
+        TEST_PATHS,
+        TEST_RUNNER
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
+++ b/leaders/src/main/java/edu/cornell/repository/ConfigParser.java
@@ -1,12 +1,13 @@
 package edu.cornell.repository;
 
+import lombok.NonNull;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
-import lombok.NonNull;
 
 /**
  * Parses the config file of the repository.

--- a/leaders/src/main/java/edu/cornell/repository/ConfigSyntaxException.java
+++ b/leaders/src/main/java/edu/cornell/repository/ConfigSyntaxException.java
@@ -1,0 +1,15 @@
+package edu.cornell.repository;
+
+import java.io.Serial;
+
+/**
+Thrown whenever syntax of the config file is incorrect.
+*/
+public class ConfigSyntaxException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 7654321L;
+
+    public ConfigSyntaxException(String message) {
+        super(message);
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -1,17 +1,15 @@
 package edu.cornell.repository;
 
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * A class representing a Java project using JUnit 5 for testing

--- a/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -2,6 +2,8 @@ package edu.cornell.repository;
 
 import java.io.File;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -20,6 +22,6 @@ final class JUnit5RepositoryImpl extends Repository {
     @Override
     public @NonNull Set<String> getTests() {
         // TODO: Test discoverer
-        return null;
+        return super.getConfig().getTestPaths().stream().collect(Collectors.toSet());
     }
 }

--- a/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -1,0 +1,25 @@
+package edu.cornell.repository;
+
+import java.io.File;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+
+/**
+ * A class representing a Java project using JUnit 5 for testing
+ */
+@EqualsAndHashCode(callSuper = true)
+@ToString
+final class JUnit5RepositoryImpl extends Repository {
+
+    JUnit5RepositoryImpl(@NonNull File rootDir) throws ConfigSyntaxException {
+        super(rootDir);
+    }
+
+    @Override
+    public @NonNull Set<String> getTests() {
+        // TODO: Test discoverer
+        return null;
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -1,17 +1,23 @@
 package edu.cornell.repository;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A class representing a Java project using JUnit 5 for testing
  */
 @EqualsAndHashCode(callSuper = true)
+@Slf4j
 @ToString
 final class JUnit5RepositoryImpl extends Repository {
 
@@ -22,6 +28,16 @@ final class JUnit5RepositoryImpl extends Repository {
     @Override
     public @NonNull Set<String> getTests() {
         // TODO: Test discoverer
-        return super.getConfig().getTestPaths().stream().collect(Collectors.toSet());
+        List<String> configTestPaths = getConfig().getTestPaths();
+        Set<String> classes = new HashSet<>();
+        try {
+            for(String testPath : configTestPaths) {
+                classes.addAll(JUnitClassFinder.findJUnitClasses(getRootDir() + testPath.trim()));
+            }
+        } catch (MalformedURLException | ClassNotFoundException e) {
+            LOGGER.error("Error in JUnit5RepositoryImpl: ", e);
+        }
+
+        return classes;
     }
 }

--- a/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -27,7 +27,6 @@ final class JUnit5RepositoryImpl extends Repository {
 
     @Override
     public @NonNull Set<String> getTests() {
-        // TODO: Test discoverer
         List<String> configTestPaths = getConfig().getTestPaths();
         Set<String> classes = new HashSet<>();
         try {

--- a/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
@@ -7,8 +7,10 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Loads .class Files into the current thread.

--- a/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
@@ -23,10 +23,10 @@ public class JUnitClassFinder extends ClassLoader {
     };
 
     /**
-     * Loads the .class files from the given path and all of its subdirectories.
+     * Finds all JUnit classes in the subdirectories of directory path
      * <br><b>NOTE</b>: Files are loaded into the current thread.</br>
      * @param directoryPath - The path containing the .class files to load.
-     * @Precondition: The directory contains the test .class files as well as the base test path.
+     * @Precondition: The directory has a subdirectory of /test/java or /java/test
      */
     public static Set<String> findJUnitClasses(String directoryPath) throws PathIsNotValidException, MalformedURLException, ClassNotFoundException {
         File directory = new File(directoryPath);
@@ -65,6 +65,7 @@ public class JUnitClassFinder extends ClassLoader {
         return classes;
     }
 
+    // Returns a record of both all the required classpaths and .class files and a custom class loader
     private static ClassLoadingResult loadClassResults(File directory) throws MalformedURLException {
         // Check if the directory is valid
         if (!directory.exists() || !directory.isDirectory()) {
@@ -93,7 +94,7 @@ public class JUnitClassFinder extends ClassLoader {
     private record ClassLoadingResult(URL[] urlArray, ClassLoader customClassLoader) {
     }
 
-    // Finds all files in the subdirectories of the given directory.
+    // Finds all files in the subdirectories of the given directory. Only add to urls if a matching directory is found
     private static void searchSubdirectories(File directory, List<URL> urls) throws MalformedURLException {
         File[] files = directory.listFiles();
 
@@ -111,6 +112,7 @@ public class JUnitClassFinder extends ClassLoader {
         }
     }
 
+    // Detect if the current directory contains the specific substring representing the test path
     private static boolean doesDirectoryMatch(String directoryPath) {
         for (String s : LIKELY_PACKAGE_STRUCTURE_LIST) {
             if(directoryPath.contains(s)) { return true; }

--- a/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
+++ b/leaders/src/main/java/edu/cornell/repository/JUnitClassFinder.java
@@ -1,38 +1,71 @@
-package edu.cornell.testenv.testcontext;
+package edu.cornell.repository;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Loads .class Files into the current thread.
  */
 
 @Slf4j
-public class JUnitContextClassLoader extends ClassLoader {
+public class JUnitClassFinder extends ClassLoader {
 
     private static final String[] LIKELY_PACKAGE_STRUCTURE_LIST = {
-            "/test/java",
-            "/java/test",
-            "/main/java",
-            "/java/main"
+      "/test/java",
+      "/java/test"
     };
 
     /**
      * Loads the .class files from the given path and all of its subdirectories.
      * <br><b>NOTE</b>: Files are loaded into the current thread.</br>
      * @param directoryPath - The path containing the .class files to load.
-     * @Precondition: Both the test .class files and its dependencies (as a transitive closure)
-     * are in the given directoryPath.
+     * @Precondition: The directory contains the test .class files as well as the base test path.
      */
-    public static ClassLoader loadClassesFromDirectory(String directoryPath) throws PathIsNotValidException, MalformedURLException {
+    public static Set<String> findJUnitClasses(String directoryPath) throws PathIsNotValidException, MalformedURLException, ClassNotFoundException {
         File directory = new File(directoryPath);
 
+        ClassLoadingResult result = loadClassResults(directory);
+        Thread.currentThread().setContextClassLoader(result.customClassLoader());
+
+        Set<String> classes = new HashSet<>();
+
+        for(URL url : result.urlArray()) {
+            String fileName = url.getFile();
+
+            if(!(new File(fileName).isFile()) && fileName.length() > 0) { continue; }
+
+            String className = "";
+            for(String s : LIKELY_PACKAGE_STRUCTURE_LIST) {
+                if(fileName.contains(s)) {
+                    className = fileName.substring(fileName.indexOf(s) + s.length() + 1, fileName.lastIndexOf(".")).replace(File.separator, ".");
+                }
+            }
+
+            try {
+                Class<?> loadedClass = Thread.currentThread().getContextClassLoader().loadClass(className);
+                Method[] methods = loadedClass.getDeclaredMethods();
+
+                for (Method method : methods) {
+                    if (method.getAnnotation(org.junit.jupiter.api.Test.class) != null) {
+                        classes.add(className);
+                        break;
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+
+            }
+        }
+        return classes;
+    }
+
+    private static ClassLoadingResult loadClassResults(File directory) throws MalformedURLException {
         // Check if the directory is valid
         if (!directory.exists() || !directory.isDirectory()) {
             throw new PathIsNotValidException("The given path " + directory.toPath() + " is invalid (missing or not a directory).", null);
@@ -40,11 +73,10 @@ public class JUnitContextClassLoader extends ClassLoader {
 
         List<URL> urls = new ArrayList<>();
 
-        // Turn all files found in subdirectories into URLs
-        getSubdirectories(directory, urls);
+        searchSubdirectories(directory, urls);
 
         if (urls.size() == 0) {
-            throw new PathIsNotValidException("Cannot find class path in " + directory.toPath() + "", null);
+            throw new PathIsNotValidException("Cannot find test class path in " + directory.toPath() + "", null);
         }
 
         // Add all .class or .jar files within subdirectories
@@ -54,11 +86,15 @@ public class JUnitContextClassLoader extends ClassLoader {
 
         // Create a new class loader with the specified URLs
         ClassLoader customClassLoader = new URLClassLoader(urlArray, Thread.currentThread().getContextClassLoader());
-        return customClassLoader;
+        ClassLoadingResult result = new ClassLoadingResult(urlArray, customClassLoader);
+        return result;
+    }
+
+    private record ClassLoadingResult(URL[] urlArray, ClassLoader customClassLoader) {
     }
 
     // Finds all files in the subdirectories of the given directory.
-    private static void getSubdirectories(File directory, List<URL> urls) throws MalformedURLException {
+    private static void searchSubdirectories(File directory, List<URL> urls) throws MalformedURLException {
         File[] files = directory.listFiles();
 
         if (files != null) {
@@ -69,7 +105,7 @@ public class JUnitContextClassLoader extends ClassLoader {
                         urls.add(file.toURI().toURL());
                     }
                     // Continue searching in the subdirectory
-                    getSubdirectories(file, urls);
+                    searchSubdirectories(file, urls);
                 }
             }
         }

--- a/leaders/src/main/java/edu/cornell/repository/PathIsNotValidException.java
+++ b/leaders/src/main/java/edu/cornell/repository/PathIsNotValidException.java
@@ -1,4 +1,4 @@
-package edu.cornell.partitioner;
+package edu.cornell.repository;
 
 import java.io.Serial;
 

--- a/leaders/src/main/java/edu/cornell/repository/Repository.java
+++ b/leaders/src/main/java/edu/cornell/repository/Repository.java
@@ -1,14 +1,14 @@
 package edu.cornell.repository;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.util.List;
-import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 /**
  * A representation of a Java project to build and test

--- a/leaders/src/main/java/edu/cornell/repository/Repository.java
+++ b/leaders/src/main/java/edu/cornell/repository/Repository.java
@@ -1,0 +1,42 @@
+package edu.cornell.repository;
+
+import java.io.File;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A representation of a Java project to build and test
+ */
+@Slf4j
+@EqualsAndHashCode
+@ToString
+public abstract class Repository {
+
+    /**
+     * The root directory of the project once it's on disk
+     */
+    private final @NonNull File rootDir;
+    /**
+     * The configuration for SPEED found in this repository
+     */
+    private final @NonNull Config config;
+
+    /**
+     * Creates a new Repository with the given root directory
+     * @param rootDir the root directory of the project on disk
+     * @throws ConfigSyntaxException if there is a syntax error with the config file
+     */
+    Repository(@NonNull File rootDir) throws ConfigSyntaxException {
+        this.rootDir = rootDir;
+        this.config = new Config(rootDir.getAbsolutePath() + "/.speed");
+    }
+
+    /**
+     * Returns the set of tests found in the repository
+     * @return the set of tests found in the repository
+     */
+    public abstract @NonNull Set<String> getTests();
+}

--- a/leaders/src/main/java/edu/cornell/repository/Repository.java
+++ b/leaders/src/main/java/edu/cornell/repository/Repository.java
@@ -1,6 +1,7 @@
 package edu.cornell.repository;
 
 import java.io.File;
+import java.util.List;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -19,10 +20,27 @@ public abstract class Repository {
      * The root directory of the project once it's on disk
      */
     private final @NonNull File rootDir;
+
+    /**
+     * The root directory of the project
+     * @return File - the root directory of the project
+     */
+    public File getRootDir() {
+        return rootDir;
+    }
+
     /**
      * The configuration for SPEED found in this repository
      */
     private final @NonNull Config config;
+
+    /**
+     * The configuration for SPEED
+     * @return Config - the configuration object for SPEED
+     */
+    public Config getConfig() {
+        return config;
+    }
 
     /**
      * Creates a new Repository with the given root directory

--- a/leaders/src/main/java/edu/cornell/repository/RepositoryBuildException.java
+++ b/leaders/src/main/java/edu/cornell/repository/RepositoryBuildException.java
@@ -1,0 +1,20 @@
+package edu.cornell.repository;
+
+import java.io.Serial;
+
+/**
+ * An exception that is generated when a repository build fails
+ */
+public class RepositoryBuildException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 1234567L;
+
+    /**
+     * Creates a new RepositoryBuildException with the given message and backtrace
+     * @param message the message of the exception
+     * @param backtrace the backtrace of the exception
+     */
+    public RepositoryBuildException(String message, Throwable backtrace) {
+        super(message, backtrace);
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/RepositoryCloneException.java
+++ b/leaders/src/main/java/edu/cornell/repository/RepositoryCloneException.java
@@ -1,0 +1,20 @@
+package edu.cornell.repository;
+
+import java.io.Serial;
+
+/**
+ * An exception that is generated when a repository build fails
+ */
+public class RepositoryCloneException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 1234565L;
+
+    /**
+     * Creates a new RepositoryCloneException with the given message and backtrace
+     * @param message the message of the exception
+     * @param backtrace the backtrace of the exception
+     */
+    public RepositoryCloneException(String message, Throwable backtrace) {
+        super(message, backtrace);
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/RepositoryFactory.java
+++ b/leaders/src/main/java/edu/cornell/repository/RepositoryFactory.java
@@ -1,0 +1,120 @@
+package edu.cornell.repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import lombok.Cleanup;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ProgressMonitor;
+
+/**
+ * A factory class to create Projects from repositories and artifact storage
+ * @author Jacob Kerr
+ */
+@Slf4j
+public final class RepositoryFactory {
+
+    /** The directory to clone the workplace to */
+    private static final @NonNull File WORKSPACE = generateWorkplace();
+
+    private RepositoryFactory() {
+    }
+
+    private static @NonNull File generateWorkplace() {
+        try {
+            return Files.createTempDirectory("speed_").toFile();
+        } catch (IOException e) {
+            LOGGER.error("Unable to make cloning directory", e);
+            System.exit(1);
+            return null; // Unreachable statement
+        }
+    }
+
+    /**
+     * Clones a project from a git repository. Assumes you have already set up your git
+     * credentials if cloning from a private or otherwise protected repository
+     * @param url the url to clone the repo from
+     * @param branch the branch to clone
+     * @return a Project object representing the clone project
+     * @throws GitAPIException when a problem arises with cloning the repository
+     */
+    public static @NonNull Repository fromGitRepo(@NonNull String url, @NonNull String branch)
+            throws RepositoryCloneException {
+        try {
+            String[] split = url.split("/");
+            String name = split[split.length - 1].replaceAll(".git", "");
+            File topDir = Paths.get(WORKSPACE.getAbsolutePath() + name).toFile();
+            @Cleanup Git repo = Git.cloneRepository()
+                    .setURI(url)
+                    .setBranch(branch)
+                    .setDirectory(topDir)
+                    .setDepth(1)
+                    .setProgressMonitor(new GitProgressLog())
+                    .call();
+            return new JUnit5RepositoryImpl(topDir);
+        } catch (GitAPIException | ConfigSyntaxException e) {
+            LOGGER.error("Error while cloning repository " + url, e);
+            throw new RepositoryCloneException("Error while cloning repository " + url, e);
+        }
+    }
+
+    @Slf4j
+    private static final class GitProgressLog implements ProgressMonitor {
+
+        /** The total number of tasks to run */
+        private int totalTasks;
+        /** The number of completed tasks */
+        private int currentTasks;
+        /** The name of the current task */
+        private @NonNull String currentTaskName;
+        /** The total number of work units to be done on the current task */
+        private int totalWork;
+        /** The number of completed work units */
+        private int currentWork;
+
+        private GitProgressLog() {
+            totalTasks = 0;
+            currentTasks = 0;
+            totalWork = 0;
+            currentWork = 0;
+            currentTaskName = "";
+        }
+
+        @Override
+        public void start(int totalTasks) {
+            this.totalTasks = totalTasks;
+            LOGGER.info("GIT TASK START");
+        }
+
+        @Override
+        public void beginTask(String title, int totalWork) {
+            this.currentWork = 0;
+            this.totalWork = totalWork;
+            this.currentTaskName = title;
+            LOGGER.info("GIT SUBTASK START: " + title +
+                    " (" + currentTasks + "/" + totalTasks + ")");
+        }
+
+        @Override
+        public void update(int completed) {
+            currentWork += completed;
+            LOGGER.info(currentTaskName + ": " + currentWork + "/" + totalWork);
+        }
+
+        @Override
+        public void endTask() {
+            currentTasks++;
+            LOGGER.info("GIT SUBTASK END: " + currentTaskName);
+        }
+
+        @Override
+        public boolean isCancelled() {return false;} // Should never be cancelled by user
+
+        @Override
+        public void showDuration(boolean enabled) { } // Do nothing
+    }
+}

--- a/leaders/src/main/java/edu/cornell/repository/RepositoryFactory.java
+++ b/leaders/src/main/java/edu/cornell/repository/RepositoryFactory.java
@@ -1,15 +1,16 @@
 package edu.cornell.repository;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import lombok.Cleanup;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ProgressMonitor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * A factory class to create Projects from repositories and artifact storage

--- a/workers/src/main/java/edu/cornell/repository/Config.java
+++ b/workers/src/main/java/edu/cornell/repository/Config.java
@@ -36,4 +36,8 @@ public class Config {
     public @NonNull List<String> getBuildCommands() {
         return parser.getConfigMapCategory(ConfigParser.Category.BUILD_COMMANDS);
     }
+
+    public @NonNull List<String> getTestPaths() {
+        return parser.getConfigMapCategory(ConfigParser.Category.TEST_PATHS);
+    }
 }

--- a/workers/src/main/java/edu/cornell/repository/ConfigParser.java
+++ b/workers/src/main/java/edu/cornell/repository/ConfigParser.java
@@ -72,7 +72,7 @@ public class ConfigParser {
             } else if (line.startsWith("-")) {
                 if (!categoryOpen)
                     throw new ConfigSyntaxException("Item outside of a category: " + line);
-                currentItems.add(line.substring(1));
+                currentItems.add(line.substring(1).trim());
             } else if (!line.trim().isEmpty()) {
                 if (!categoryOpen || currentItems.isEmpty())
                     throw new ConfigSyntaxException("Continuation line outside of an item: " + line);

--- a/workers/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/workers/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -9,6 +9,7 @@ import lombok.ToString;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A class representing a Java project using JUnit 5 for testing
@@ -30,6 +31,9 @@ final class JUnit5RepositoryImpl extends Repository {
     public void test(@NonNull List<String> tests, TestOutputStream output) {
         JUnitTestContext context = new JUnitTestContext(tests);
         JUnit5TestRunner runner = new JUnit5TestRunner();
-        runner.runTest(context, output, getRootDir());
+        List<String> configTestPaths = getConfig().getTestPaths();
+        for(String testPath : configTestPaths) {
+            runner.runTest(context, output, new File(getRootDir() + testPath.trim()));
+        }
     }
 }

--- a/workers/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
+++ b/workers/src/main/java/edu/cornell/repository/JUnit5RepositoryImpl.java
@@ -9,7 +9,6 @@ import lombok.ToString;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A class representing a Java project using JUnit 5 for testing

--- a/workers/src/main/java/edu/cornell/testenv/testcontext/JUnitContextClassLoader.java
+++ b/workers/src/main/java/edu/cornell/testenv/testcontext/JUnitContextClassLoader.java
@@ -27,8 +27,8 @@ public class JUnitContextClassLoader extends ClassLoader {
      * Loads the .class files from the given path and all of its subdirectories.
      * <br><b>NOTE</b>: Files are loaded into the current thread.</br>
      * @param directoryPath - The path containing the .class files to load.
-     * @Precondition: Both the test .class files and its dependencies (as a transitive closure)
-     * are in the given directoryPath.
+     * @Precondition: test package+classname files are in the direct subdirectory of "/test/java/" or "/java/test" and
+     * source package+classname files are in the direct subdirectory of "/main/java" or "/java/main"
      */
     public static ClassLoader loadClassesFromDirectory(String directoryPath) throws PathIsNotValidException, MalformedURLException {
         File directory = new File(directoryPath);
@@ -57,7 +57,7 @@ public class JUnitContextClassLoader extends ClassLoader {
         return customClassLoader;
     }
 
-    // Finds all files in the subdirectories of the given directory.
+    // Finds all files in the subdirectories of the given directory. Add if it contains a matching subdirectory
     private static void getSubdirectories(File directory, List<URL> urls) throws MalformedURLException {
         File[] files = directory.listFiles();
 
@@ -75,6 +75,7 @@ public class JUnitContextClassLoader extends ClassLoader {
         }
     }
 
+    // Detects if a directory contains a substring representing a package structure for the .class files
     private static boolean doesDirectoryMatch(String directoryPath) {
         for (String s : LIKELY_PACKAGE_STRUCTURE_LIST) {
             if(directoryPath.contains(s)) { return true; }

--- a/workers/src/main/java/edu/cornell/testenv/testrunner/JUnit5TestRunner.java
+++ b/workers/src/main/java/edu/cornell/testenv/testrunner/JUnit5TestRunner.java
@@ -30,10 +30,11 @@ public class JUnit5TestRunner implements TestRunner {
      * @return boolean of whether all JUnit tests passed
      */
     @Override
-    public boolean runTest(TestEnvContext context, TestOutputStream outputStream, File rootDir) {
+    public boolean runTest(TestEnvContext context, TestOutputStream outputStream, File baseDir) {
         try {
             //Assumption is class files live in /build/classes/java/ (and the .class files in some subdirectory)
-            String baseRootPath = rootDir.toString() + "/build/classes/java/".replaceAll("/", File.separator);
+            String baseRootPath = baseDir.toString();
+            LOGGER.info("Discovery .class files in location: " + baseRootPath);
 
             // Open a Launcher session
             try (LauncherSession session = LauncherFactory.openSession()) {

--- a/workers/src/main/java/edu/cornell/testenv/testrunner/JUnit5TestRunner.java
+++ b/workers/src/main/java/edu/cornell/testenv/testrunner/JUnit5TestRunner.java
@@ -32,7 +32,6 @@ public class JUnit5TestRunner implements TestRunner {
     @Override
     public boolean runTest(TestEnvContext context, TestOutputStream outputStream, File baseDir) {
         try {
-            //Assumption is class files live in /build/classes/java/ (and the .class files in some subdirectory)
             String baseRootPath = baseDir.toString();
             LOGGER.info("Discovery .class files in location: " + baseRootPath);
 


### PR DESCRIPTION
### Summary

This PR creates test discovery and partitioning systems. Currently, the tests are partitioned "evenly" onto different workers without regard for execution time. "Evenly" is defined as each worker having roughly the same number of tests to execute. 

This PR also adds a new environment variable to the leader, `SPEED_NUM_WORKERS`, which is the number of workers to spawn. This can be made dynamic at a later day but is manually set by the user at leader execution time. 

### Known Issues
While not a bug, the code between the `repository` packages in the leaders and workers is extremely similar. We should consider a refactor at a later time.

### Assumptions Made 
- For the leader we assume that in the provided TEST_PATH directory to look through, there is eventually some subdirectory `/test/java` or `/java/test` with the `.class` files for testing specifically
- For the worker we assume that in the provided TEST_PATH directory to look through, there is eventually some subdirectory `/test/java` or `/java/test` with the `.class files `for testing specifically and also that there is eventually some subdirectory `/main/java` or `/java/main` with the source `.class` files
- We assume a JUnit class to be a class in the testing path where in the class has at least one method that has the `@Test` annotation

Issue: #14 